### PR TITLE
Chore add messages rate

### DIFF
--- a/mqtt/emqx.conf
+++ b/mqtt/emqx.conf
@@ -40,6 +40,7 @@ retainer {
 
 listeners.tcp.default {
   bind = "0.0.0.0:1883"
+  messages_rate = "80/s"
   max_connections = 1024000
 }
 


### PR DESCRIPTION
init with 80/s
- based on the number of connections x2
- cause when control publish will be used by eoh's client

Note: maybe more, 1 acc log in multiple pc, then control at same time